### PR TITLE
feat: Implement multiple UI/UX enhancements

### DIFF
--- a/react-app/src/components/dmx/DmxChannel.module.scss
+++ b/react-app/src/components/dmx/DmxChannel.module.scss
@@ -44,7 +44,7 @@
     margin: 0;
     padding: 2rem;
     border-radius: 0;
-    background: var(--bg-primary);
+    background-color: #18181b; /* Ensuring an opaque background, var(--bg-primary) might be semi-transparent */
     transform: none;
     width: 100%;
     height: 100vh;

--- a/react-app/src/components/layout/Navbar.module.scss
+++ b/react-app/src/components/layout/Navbar.module.scss
@@ -1,53 +1,69 @@
-.navbar {
+/* Container for the toggle button and the nav content */
+.navbarContainer {
+  position: sticky; /* Keeps the whole block sticky */
+  top: 0;
+  z-index: 1001; /* Ensure toggle is above other sticky elements if needed */
+  margin-bottom: 1.5rem; /* Retain original bottom margin */
+  display: flex; /* Align toggle and nav content */
+  align-items: flex-start; /* Align items to the top */
+  gap: 0.5rem; /* Space between toggle and nav content if side-by-side */
+}
+
+/* Styles for the actual navigation content area */
+.navContent {
   display: flex;
-  justify-content: space-between;
+  justify-content: space-between; /* This was on .navbar before */
   gap: 1rem;
   padding: 1rem;
   background: var(--bg-secondary);
   backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px);
   border-radius: 8px;
-  margin-bottom: 1.5rem;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
-  position: sticky;
-  top: 0;
-  z-index: 1000;
+  /* position: sticky, top, z-index, margin-bottom are now on navbarContainer */
   animation: rainbow-bg 10s linear infinite;
   pointer-events: auto;
-  transition: all 0.3s ease;
+  transition: all 0.3s ease; /* For smooth expand if not using display:none */
+  flex-grow: 1; /* Allow navContent to take available space */
 
-  @keyframes rainbow-bg {
+
+  @keyframes rainbow-bg { /* Keep animation definition if used by navContent */
     0% { background-position: 0% 50%; }
     50% { background-position: 100% 50%; }
     100% { background-position: 0% 50%; }
   }
 
-  &.collapsed {
-    .navButtons {
-      max-height: 0;
-      overflow: hidden;
-      opacity: 0;
-      margin-top: 0;
-    }
+  &.navContentCollapsed {
+    display: none;
   }
+}
 
-  .collapseToggle {
-    background: none;
-    border: none;
-    color: var(--text-primary);
-    font-size: 1.2rem;
-    cursor: pointer;
-    padding: 0.5rem;
-    border-radius: 6px;
-    transition: all 0.2s ease;
-    
-    &:hover {
-      background: rgba(var(--accent-color-rgb), 0.1);
-      color: var(--accent-color);
-    }
+.collapseToggle {
+  background: var(--bg-primary-alpha, rgba(40, 40, 40, 0.7));
+  border: 1px solid var(--border-color-soft, #555);
+  color: var(--text-primary);
+  font-size: 1rem; /* Adjusted size */
+  cursor: pointer;
+  padding: 0.6rem; /* Make it squarer for icons */
+  border-radius: 6px;
+  transition: all 0.2s ease;
+  z-index: 1002; /* Above navContent if they could overlap */
+  /* position: fixed; top: 1rem; left: 1rem; if fully independent positioning is needed */
+  /* For now, it's part of the flex flow in navbarContainer */
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 40px; /* Explicit size */
+  height: 40px; /* Explicit size */
+
+  &:hover {
+    background: rgba(var(--accent-color-rgb), 0.2);
+    border-color: var(--accent-color);
+    color: var(--accent-color);
   }
+}
 
-  .navButtons {
+.navButtons {
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
@@ -128,11 +144,14 @@
       }
     }
   }
+  /* Media query adjustments might be needed for .navbarContainer and .collapseToggle as well */
   @media (max-width: 768px) {
-    padding: 0.5rem;
-    gap: 0.5rem;
-    flex-wrap: wrap;
-    justify-content: center;
+    .navContent { /* Apply responsive styles to navContent */
+      padding: 0.5rem;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+      justify-content: center;
+    }
     
     .navButton {
       min-width: auto;
@@ -152,3 +171,5 @@
     }
   }
 }
+/* Ensure .navbar class from previous state is removed or updated if it was used elsewhere */
+/* For example, if any global styles or other components referred to .navbar directly */

--- a/react-app/src/components/layout/Navbar.tsx
+++ b/react-app/src/components/layout/Navbar.tsx
@@ -92,6 +92,23 @@ export const Navbar: React.FC = () => {
   const { theme } = useTheme()
   const [activeView, setActiveView] = useState<ViewType>('main')
   const [isCollapsed, setIsCollapsed] = useState(false)
+
+  const handleViewChange = (view: ViewType) => {
+    setActiveView(view)
+    window.dispatchEvent(new CustomEvent('changeView', {
+      detail: { view }
+    }))
+  }
+
+  const toggleCollapse = () => {
+    setIsCollapsed(!isCollapsed)
+  }
+import { Menu, X } from 'lucide-react'; // Using lucide-react icons for toggle
+
+export const Navbar: React.FC = () => {
+  const { theme } = useTheme()
+  const [activeView, setActiveView] = useState<ViewType>('main')
+  const [isCollapsed, setIsCollapsed] = useState(false)
   
   const handleViewChange = (view: ViewType) => {
     setActiveView(view)
@@ -104,28 +121,34 @@ export const Navbar: React.FC = () => {
     setIsCollapsed(!isCollapsed)
   }
   
+  // The parent div now controls the overall block, its margin, and stickiness.
+  // The toggle button is outside the element that gets display:none.
   return (
-    <nav className={`${styles.navbar} ${isCollapsed ? styles.collapsed : ''}`}>
-      <Sparkles />
+    <div className={styles.navbarContainer}>
       <button 
         className={styles.collapseToggle}
         onClick={toggleCollapse}
         title={isCollapsed ? "Expand navigation" : "Collapse navigation"}
       >
-        <i className={`fas ${isCollapsed ? 'fa-chevron-down' : 'fa-chevron-up'}`}></i>
+        {isCollapsed ? <Menu size={24} /> : <X size={24} />} {/* Changed icon based on state */}
       </button>
-      <div className={styles.navButtons}>
-        {navItems.map((item) => (
-          <button
+      <nav className={`${styles.navContent} ${isCollapsed ? styles.navContentCollapsed : ''}`}>
+        <Sparkles />
+        {/* Removed the old internal toggle button from here */}
+        <div className={styles.navButtons}>
+          {navItems.map((item) => (
+            <button
             key={item.id}
             className={`${styles.navButton} ${activeView === item.id ? styles.active : ''}`}
             onClick={() => handleViewChange(item.id)}
             title={item.title.standard}
           >
-            <i className={`fas ${item.icon}`}></i>
-            <span>{item.title[theme]}</span>
-          </button>
-        ))}      </div>
-    </nav>
+              <i className={`fas ${item.icon}`}></i>
+              <span>{item.title[theme]}</span>
+            </button>
+          ))}
+        </div>
+      </nav>
+    </div>
   )
 }

--- a/react-app/src/components/midi/MidiClock.module.scss
+++ b/react-app/src/components/midi/MidiClock.module.scss
@@ -1,0 +1,161 @@
+.midiClock {
+  position: absolute;
+  top: 20px; /* Default position */
+  left: 860px; /* Default position next to OSC Monitor */
+  width: 280px;
+  background-color: #2c2c2c;
+  border: 2px solid #555;
+  border-radius: 6px;
+  color: #eaeaea;
+  font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
+  box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+  transition: all 0.3s ease;
+  z-index: 998; /* Below other monitors if overlapping */
+  display: flex;
+  flex-direction: column;
+
+  &.collapsed {
+    width: auto;
+    min-width: 150px;
+    height: auto;
+  }
+
+  &.externalSync {
+    border-left: 3px solid #61dafb; // Indicate active external sync
+  }
+}
+
+.header {
+  display: flex;
+  align-items: center;
+  background-color: #383838;
+  padding: 6px 10px;
+  cursor: grab;
+  user-select: none;
+  border-bottom: 1px solid #4a4a4a;
+
+  &:hover {
+    background-color: #4a4a4a;
+  }
+}
+
+.dragHandle {
+  margin-right: 8px;
+  color: #999;
+  cursor: grab;
+}
+
+.title {
+  font-weight: bold;
+  color: #61dafb; /* A distinct color for the clock */
+  /* margin-right: auto; */ /* Let syncStatus take space */
+  flex-grow: 1; /* Allow title to take available space before controls */
+}
+
+.syncStatus {
+  font-size: 0.75em;
+  padding: 2px 6px;
+  border-radius: 3px;
+  margin-left: 8px;
+  margin-right: auto; /* Pushes controls to the right */
+  display: flex;
+  align-items: center;
+  gap: 4px;
+
+  &.synced {
+    background-color: #2a9d8f; // Teal for synced
+    color: #fff;
+  }
+
+  &.notSynced {
+    background-color: #e76f51; // Coral for not synced/internal
+    color: #fff;
+  }
+}
+
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  button {
+    background: none;
+    border: none;
+    color: #ccc;
+    padding: 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background-color: #555;
+      color: #fff;
+    }
+  }
+}
+
+.content {
+  padding: 12px;
+  background-color: #252525;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.timeDisplay {
+  font-size: 1.8em;
+  color: #61dafb;
+  font-weight: bold;
+  letter-spacing: 1px;
+  margin-bottom: 5px; /* Added margin */
+}
+
+.bpmDisplay {
+  font-size: 1.2em;
+  color: #eee;
+  background-color: #333;
+  padding: 5px 10px;
+  border-radius: 4px;
+  width: fit-content;
+  margin-bottom: 10px; /* Added margin */
+}
+
+.transportControls {
+  display: flex;
+  gap: 8px;
+  margin-top: 8px;
+
+  button {
+    background-color: #4f4f4f;
+    color: #fff;
+    border: none;
+    padding: 8px 12px;
+    border-radius: 4px;
+    cursor: pointer;
+    font-size: 0.9em;
+
+    &:hover:not(:disabled) {
+      background-color: #61dafb;
+      color: #252525;
+    }
+
+    &:disabled {
+      background-color: #3a3a3a;
+      color: #777;
+      cursor: not-allowed;
+    }
+  }
+}
+
+.linkStatus {
+  font-size: 0.8em;
+  color: #aaa;
+  margin-top: 5px;
+  padding: 3px 6px;
+  background-color: rgba(0,0,0,0.2);
+  border-radius: 3px;
+}

--- a/react-app/src/components/midi/MidiClock.tsx
+++ b/react-app/src/components/midi/MidiClock.tsx
@@ -1,0 +1,109 @@
+import React, { useState, useEffect, useRef } from 'react';
+import Draggable from 'react-draggable';
+import { Minimize2, Maximize2, GripVertical, Zap, ZapOff } from 'lucide-react'; // Added Zap icons
+import styles from './MidiClock.module.scss';
+import { useStore } from '../../store';
+
+export const MidiClock: React.FC = () => {
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [currentTime, setCurrentTime] = useState(new Date());
+  const nodeRef = useRef(null);
+
+  const { selectedMidiClockHostId, availableMidiClockHosts } = useStore(state => ({
+    selectedMidiClockHostId: state.selectedMidiClockHostId,
+    availableMidiClockHosts: state.availableMidiClockHosts,
+  }));
+
+  // Placeholder for actual MIDI clock data from store or Link
+  // const { bpm, beat, bar, isPlaying } = useStore(state => state.midiClockData) || { bpm: 120, beat: 0, bar: 0, isPlaying: false };
+  const bpm = 120.00; // Placeholder
+  const isPlaying = false; // Placeholder
+
+  useEffect(() => {
+    const timerId = setInterval(() => {
+      setCurrentTime(new Date());
+    }, 1000);
+    return () => clearInterval(timerId);
+  }, []);
+
+  const handleDragStart = (e: any) => {
+    if (e.target.closest('button')) {
+      return false;
+    }
+  };
+
+  const renderHeader = () => {
+    const selectedHost = availableMidiClockHosts.find(host => host.id === selectedMidiClockHostId);
+    const syncStatusText = selectedHost && selectedHost.id !== 'none'
+      ? `Sync: ${selectedHost.name}`
+      : 'Internal Clock';
+    const isActuallySynced = selectedHost && selectedHost.id !== 'none'; // Placeholder for real sync status
+
+    return (
+      <div className={`${styles.header} handle`}>
+        <GripVertical size={18} className={styles.dragHandle} />
+        <span className={styles.title}>MIDI Clock</span>
+        {!isCollapsed && (
+          <span className={`${styles.syncStatus} ${isActuallySynced ? styles.synced : styles.notSynced}`}>
+            {isActuallySynced ? <Zap size={12} /> : <ZapOff size={12} />}
+            {syncStatusText}
+          </span>
+        )}
+        <div className={styles.controls}>
+          <button onClick={() => setIsCollapsed(!isCollapsed)}>
+            {isCollapsed ? <Maximize2 size={14} /> : <Minimize2 size={14} />}
+          </button>
+        </div>
+      </div>
+    );
+  };
+
+  const renderContent = () => {
+    if (isCollapsed) {
+      return null;
+    }
+    // const currentBeat = beat % 4; // Assuming 4/4 time
+    // const currentBar = Math.floor(beat / 4) + bar;
+
+    return (
+      <div className={styles.content}>
+        <div className={styles.timeDisplay}>
+          {currentTime.toLocaleTimeString()}
+        </div>
+        <div className={styles.bpmDisplay}>
+          {/* BPM: {bpm.toFixed(2)} | Bar: {currentBar} | Beat: {currentBeat + 1} */}
+          BPM: {bpm.toFixed(2)}
+        </div>
+        {/* Placeholder for actual transport controls based on sync source */}
+        <div className={styles.transportControls}>
+          <button disabled={selectedMidiClockHostId !== 'none'}>▶️ Play</button>
+          <button disabled={selectedMidiClockHostId !== 'none'}>⏹️ Stop</button>
+          {/* <button>Tap</button> */}
+        </div>
+         {selectedMidiClockHostId === 'ableton-link' && (
+          <div className={styles.linkStatus}>
+            {/* Placeholder for Ableton Link specific status, e.g., number of peers */}
+            Link Peers: 0
+          </div>
+        )}
+      </div>
+    );
+  };
+
+  const clockClasses = [
+    styles.midiClock,
+    isCollapsed ? styles.collapsed : '',
+    selectedMidiClockHostId !== 'none' ? styles.externalSync : '',
+  ].join(' ');
+
+  return (
+    <Draggable nodeRef={nodeRef} handle=".handle" onStart={handleDragStart}>
+      <div ref={nodeRef} className={clockClasses}>
+        {renderHeader()}
+        {renderContent()}
+      </div>
+    </Draggable>
+  );
+};
+
+export default MidiClock;

--- a/react-app/src/components/midi/MidiMonitor.module.scss
+++ b/react-app/src/components/midi/MidiMonitor.module.scss
@@ -1,7 +1,8 @@
 .midiMonitor {
-  position: fixed;
+  /* Default position, will be overridden by draggable or if pinned */
+  position: absolute;
   bottom: 20px;
-  right: 440px; /* Adjusted to make space for OSC Monitor (400px width + 20px margin + 20px own margin) */
+  left: 20px;
   width: 400px;
   max-height: 300px;
   background-color: #2a2a2a;
@@ -13,10 +14,19 @@
   transition: all 0.3s ease;
   z-index: 1000;
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  &.pinned {
+    position: fixed !important; /* Important to override draggable styles */
+    /* Pinned position can be adjusted in the component's style prop */
+  }
   
   &.collapsed {
-    width: 180px;
+    width: auto; /* Adjust width to content when collapsed */
+    min-width: 180px; /* Ensure a minimum width */
     height: auto;
+    max-height: none; /* Allow header to define height */
   }
   
   &.flash {
@@ -30,8 +40,8 @@
   justify-content: space-between;
   align-items: center;
   background-color: #333;
-  padding: 8px 12px;
-  cursor: pointer;
+  padding: 6px 10px; /* Adjusted padding */
+  cursor: grab; /* Indicate draggable */
   user-select: none;
   
   &:hover {
@@ -39,26 +49,62 @@
   }
 }
 
+.dragHandle {
+  margin-right: 8px;
+  color: #888;
+  cursor: grab;
+}
+
 .title {
   font-weight: bold;
   color: #00ff66;
+  margin-right: auto; /* Push controls to the right */
 }
 
 .status {
-  margin-left: auto;
-  margin-right: 12px;
+  /* margin-left: auto; */ /* Removed this */
+  margin-right: 10px; /* Adjusted margin */
   font-size: 0.9em;
   color: #aaa;
 }
 
-.toggle {
-  color: #00ff66;
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 6px; /* Space between buttons */
+
+  button {
+    background: none;
+    border: none;
+    color: #ccc;
+    padding: 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background-color: #555;
+      color: #fff;
+    }
+
+    &.active {
+      background-color: #007bff;
+      color: #fff;
+    }
+  }
 }
+
+/* .toggle class removed as it's replaced by icon buttons */
 
 .content {
   padding: 10px;
-  max-height: 250px;
+  /* max-height: 250px; */ /* Let the container max-height handle this */
   overflow-y: auto;
+  background-color: #222; /* Slightly different background for content area */
+  border-top: 1px solid #444; /* Separator line */
+  flex-grow: 1; /* Allow content to take available space */
 }
 
 .noData {

--- a/react-app/src/components/midi/MidiMonitor.tsx
+++ b/react-app/src/components/midi/MidiMonitor.tsx
@@ -1,82 +1,111 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
+import Draggable, { DraggableCore } from 'react-draggable';
+import { Pin, Minimize2, Maximize2, GripVertical } from 'lucide-react';
 import { useStore } from '../../store';
 import styles from './MidiMonitor.module.scss';
 
 export const MidiMonitor: React.FC = () => {
   const midiMessages = useStore(state => state.midiMessages);
   const [lastMessages, setLastMessages] = useState<Array<any>>([]);
-  const [visible, setVisible] = useState(true);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isPinned, setIsPinned] = useState(false);
   const [flashActive, setFlashActive] = useState(false);
+  const nodeRef = useRef(null);
 
   // Update the displayed messages when new MIDI messages arrive
   useEffect(() => {
     if (midiMessages.length > 0) {
-      // Get the last 5 messages (or fewer if less are available)
       const recentMessages = midiMessages.slice(-5);
       setLastMessages(recentMessages);
-      
-      // Flash the monitor to indicate new activity
+
       setFlashActive(true);
       const timer = setTimeout(() => setFlashActive(false), 200);
       return () => clearTimeout(timer);
     }
   }, [midiMessages]);
 
-  // No messages to display
-  if (lastMessages.length === 0) {
-    return (
-      <div className={`${styles.midiMonitor} ${visible ? '' : styles.collapsed}`}>
-        <div className={styles.header} onClick={() => setVisible(!visible)}>
-          <span className={styles.title}>MIDI Monitor</span>
-          <span className={styles.toggle}>{visible ? '▼' : '◀'}</span>
+  const handleDragStart = (e: any) => {
+    // Prevent dragging when clicking on buttons
+    if (e.target.closest('button')) {
+      return false;
+    }
+  };
+
+  const renderHeader = () => (
+    <div className={`${styles.header} handle`}>
+      <GripVertical size={18} className={styles.dragHandle} />
+      <span className={styles.title}>MIDI Monitor</span>
+      {!isCollapsed && <span className={styles.status}>Recent: {midiMessages.length}</span>}
+      <div className={styles.controls}>
+        <button onClick={() => setIsPinned(!isPinned)} className={isPinned ? styles.active : ''}>
+          <Pin size={14} />
+        </button>
+        <button onClick={() => setIsCollapsed(!isCollapsed)}>
+          {isCollapsed ? <Maximize2 size={14} /> : <Minimize2 size={14} />}
+        </button>
+      </div>
+    </div>
+  );
+
+  const renderContent = () => {
+    if (isCollapsed) {
+      return null;
+    }
+
+    if (lastMessages.length === 0) {
+      return (
+        <div className={styles.content}>
+          <p className={styles.noData}>No MIDI messages received yet.</p>
+          <p className={styles.noData}>Try moving controls on your MIDI device.</p>
         </div>
-        {visible && (
-          <div className={styles.content}>
-            <p className={styles.noData}>No MIDI messages received yet.</p>
-            <p className={styles.noData}>Try moving controls on your MIDI device.</p>
+      );
+    }
+
+    return (
+      <div className={styles.content}>
+        {lastMessages.map((msg, index) => (
+          <div key={index} className={styles.messageRow}>
+            {msg._type === 'cc' && (
+              <>
+                <span className={styles.type}>CC</span>
+                <span className={styles.channel}>Ch {msg.channel + 1}</span>
+                <span className={styles.controller}>CC {msg.controller}</span>
+                <span className={styles.value}>{msg.value}</span>
+                <span className={styles.source}>{msg.source}</span>
+              </>
+            )}
+            {msg._type === 'noteon' && (
+              <>
+                <span className={styles.type}>Note</span>
+                <span className={styles.channel}>Ch {msg.channel + 1}</span>
+                <span className={styles.note}>Note {msg.note}</span>
+                <span className={styles.velocity}>Vel {msg.velocity}</span>
+                <span className={styles.source}>{msg.source}</span>
+              </>
+            )}
+            {msg._type !== 'cc' && msg._type !== 'noteon' && (
+              <span>Other: {JSON.stringify(msg)}</span>
+            )}
           </div>
-        )}
+        ))}
       </div>
     );
-  }
+  };
+
+  const monitorClasses = [
+    styles.midiMonitor,
+    flashActive ? styles.flash : '',
+    isPinned ? styles.pinned : '',
+    isCollapsed ? styles.collapsed : '',
+  ].join(' ');
 
   return (
-    <div className={`${styles.midiMonitor} ${flashActive ? styles.flash : ''} ${visible ? '' : styles.collapsed}`}>
-      <div className={styles.header} onClick={() => setVisible(!visible)}>
-        <span className={styles.title}>MIDI Monitor</span>
-        <span className={styles.status}>Recent: {midiMessages.length}</span>
-        <span className={styles.toggle}>{visible ? '▼' : '◀'}</span>
+    <Draggable nodeRef={nodeRef} handle=".handle" onStart={handleDragStart} disabled={isPinned}>
+      <div ref={nodeRef} className={monitorClasses} style={isPinned ? { position: 'fixed', top: 20, right: 20 } : {}}>
+        {renderHeader()}
+        {renderContent()}
       </div>
-      {visible && (
-        <div className={styles.content}>
-          {lastMessages.map((msg, index) => (
-            <div key={index} className={styles.messageRow}>
-              {msg._type === 'cc' && (
-                <>
-                  <span className={styles.type}>CC</span>
-                  <span className={styles.channel}>Ch {msg.channel + 1}</span>
-                  <span className={styles.controller}>CC {msg.controller}</span>
-                  <span className={styles.value}>{msg.value}</span>
-                  <span className={styles.source}>{msg.source}</span>
-                </>
-              )}
-              {msg._type === 'noteon' && (
-                <>
-                  <span className={styles.type}>Note</span>
-                  <span className={styles.channel}>Ch {msg.channel + 1}</span>
-                  <span className={styles.note}>Note {msg.note}</span>
-                  <span className={styles.velocity}>Vel {msg.velocity}</span>
-                  <span className={styles.source}>{msg.source}</span>
-                </>
-              )}
-              {msg._type !== 'cc' && msg._type !== 'noteon' && (
-                <span>Other: {JSON.stringify(msg)}</span>
-              )}
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
+    </Draggable>
   );
 };
 

--- a/react-app/src/components/osc/OscMonitor.module.scss
+++ b/react-app/src/components/osc/OscMonitor.module.scss
@@ -1,8 +1,8 @@
 .oscMonitor {
-  position: fixed;
+  /* Default position, will be overridden by draggable or if pinned */
+  position: absolute;
   bottom: 20px;
-  /* Adjust right position later to accommodate MidiMonitor */
-  right: 20px; 
+  left: 440px; /* Adjusted to be next to MidiMonitor */
   width: 400px;
   max-height: 300px;
   background-color: #2a2a2a;
@@ -12,12 +12,21 @@
   font-family: monospace;
   box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
   transition: all 0.3s ease;
-  z-index: 1000;
+  z-index: 999; /* Slightly lower than MidiMonitor if they overlap */
   overflow: hidden;
+  display: flex;
+  flex-direction: column;
+
+  &.pinned {
+    position: fixed !important;
+    /* Pinned position can be adjusted in the component's style prop */
+  }
   
   &.collapsed {
-    width: 180px;
+    width: auto; /* Adjust width to content when collapsed */
+    min-width: 180px; /* Ensure a minimum width */
     height: auto;
+    max-height: none; /* Allow header to define height */
   }
   
   &.flash {
@@ -31,8 +40,8 @@
   justify-content: space-between;
   align-items: center;
   background-color: #333;
-  padding: 8px 12px;
-  cursor: pointer;
+  padding: 6px 10px; /* Adjusted padding */
+  cursor: grab; /* Indicate draggable */
   user-select: none;
   
   &:hover {
@@ -40,26 +49,60 @@
   }
 }
 
+.dragHandle {
+  margin-right: 8px;
+  color: #888;
+  cursor: grab;
+}
+
 .title {
   font-weight: bold;
   color: #ff6600; /* OSC title color */
+  margin-right: auto; /* Push controls to the right */
 }
 
 .status {
-  margin-left: auto;
-  margin-right: 12px;
+  margin-right: 10px; /* Adjusted margin */
   font-size: 0.9em;
   color: #aaa;
 }
 
-.toggle {
-  color: #ff6600; /* OSC toggle color */
+.controls {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+
+  button {
+    background: none;
+    border: none;
+    color: #ccc;
+    padding: 4px;
+    border-radius: 3px;
+    cursor: pointer;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    &:hover {
+      background-color: #555;
+      color: #fff;
+    }
+
+    &.active {
+      background-color: #007bff; /* Same active color as MIDI monitor for consistency */
+      color: #fff;
+    }
+  }
 }
+
+/* .toggle class removed */
 
 .content {
   padding: 10px;
-  max-height: 250px;
   overflow-y: auto;
+  background-color: #222;
+  border-top: 1px solid #444;
+  flex-grow: 1;
 }
 
 .noData {
@@ -78,17 +121,18 @@
   border-left: 3px solid #ff6600; /* OSC message color */
   font-size: 0.9em;
   border-radius: 3px;
-  cursor: pointer;
+  cursor: default; /* Remove pointer cursor from message row if not interactive */
   transition: background-color 0.2s ease;
   
   &:last-child {
     margin-bottom: 0;
   }
   
-  &:hover {
+  /* Hover effect on message row can be kept if desired, or removed if tooltip is sufficient */
+  /* &:hover {
     background-color: #2a2a2a;
     border-left-color: #ffaa00;
-  }
+  } */
 }
 
 .address {
@@ -135,36 +179,49 @@
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
   backdrop-filter: blur(4px);
   border: 1px solid rgba(255, 102, 0, 0.3);
+}
+
+/* Added direct styling for tooltip header and content for clarity */
+.tooltipHeader {
+  font-weight: bold;
+  color: #ff6600; /* OSC theme color */
+  margin-bottom: 6px;
+  padding-bottom: 4px;
+  border-bottom: 1px solid rgba(255, 102, 0, 0.5);
+}
+
+.tooltipContent {
+  font-size: 0.75rem; /* Slightly larger for readability */
   
-  .tooltipAddress {
-    font-weight: bold;
-    color: #ff6600;
-    margin-bottom: 4px;
+  div {
+    margin-bottom: 3px;
   }
-  
-  .tooltipTimestamp {
-    font-size: 0.7rem;
-    color: #aaa;
-    margin-bottom: 6px;
-  }
-  
-  .tooltipArgs {
-    .tooltipArg {
-      display: block;
-      margin: 2px 0;
-      padding: 2px 4px;
-      background: rgba(255, 255, 255, 0.1);
-      border-radius: 2px;
-      
-      .argType {
-        color: #66ccff;
-        font-weight: bold;
-      }
-      
-      .argValue {
-        color: #fff;
-        margin-left: 8px;
-      }
-    }
+  strong {
+    color: #ccc; /* Lighter color for labels */
   }
 }
+
+.argsDetail {
+  margin-top: 4px;
+  padding-left: 10px;
+  border-left: 2px solid rgba(255, 102, 0, 0.4);
+}
+
+.argDetail {
+  display: flex; /* Align type and value nicely */
+  margin-bottom: 2px;
+}
+
+.argType {
+  color: #66ccff; /* Consistent with message row args */
+  font-weight: bold;
+  margin-right: 6px;
+  min-width: 20px; /* For alignment */
+}
+
+.argValue {
+  color: #fff;
+  word-break: break-all; /* Prevent overflow */
+}
+
+/* Removed duplicated .tooltipArgs, .tooltipArg, .argType, .argValue from here as they are now direct children of .hoverTooltip or part of new structure */

--- a/react-app/src/components/settings/Settings.tsx
+++ b/react-app/src/components/settings/Settings.tsx
@@ -39,6 +39,10 @@ export const Settings: React.FC = () => {
     masterSliders: state.masterSliders,
     transitionDuration: state.transitionDuration,
     setTransitionDuration: state.setTransitionDuration,
+    availableMidiClockHosts: state.availableMidiClockHosts,
+    selectedMidiClockHostId: state.selectedMidiClockHostId,
+    setSelectedMidiClockHostId: state.setSelectedMidiClockHostId,
+    setAvailableMidiClockHosts: state.setAvailableMidiClockHosts,
   }))
   
   const [artNetSettings, setArtNetSettings] = useState({ ...artNetConfig })
@@ -87,6 +91,20 @@ export const Settings: React.FC = () => {
   useEffect(() => { /* ... example slider MIDI handling ... */ }, [midiMappings, exampleSliderValue])
   const handleExampleSliderChange = (event: React.ChangeEvent<HTMLInputElement>) => { /* ... */ }
   
+  // Simulate fetching/setting available MIDI hosts
+  useEffect(() => {
+    // In a real app, this might involve navigator.requestMIDIAccess()
+    // For now, using a placeholder list and ensuring 'Ableton Sync Link' is present.
+    const hosts = [
+      { id: 'none', name: 'None (Internal Clock)' },
+      { id: 'ableton-link', name: 'Ableton Sync Link' },
+      // Example of a dynamically found MIDI output:
+      // { id: 'midi-output-123', name: 'My External Synth' }
+    ];
+    // This action is now in the store, but if we were to dynamically populate, we'd call it here.
+    // setAvailableMidiClockHosts(hosts); // Example: if fetching dynamically
+  }, []); // Removed setAvailableMidiClockHosts from deps
+
   return (
     <div className={styles.settings}>
       <h2 className={styles.sectionTitle}>
@@ -99,6 +117,38 @@ export const Settings: React.FC = () => {
         
         {/* MIDI Learn Test Section Card */}
         {/* ... */}
+
+        {/* MIDI Clock Settings Card - NEW */}
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h3>
+              {theme === 'artsnob' && 'Temporal Synchronization Nexus'}
+              {theme === 'standard' && 'MIDI Clock Settings'}
+              {theme === 'minimal' && 'Clock Sync'}
+            </h3>
+          </div>
+          <div className={styles.cardBody}>
+            <div className={styles.formGroup}>
+              <label htmlFor="midiClockHostSelect">MIDI Clock Sync Source:</label>
+              <select
+                id="midiClockHostSelect"
+                value={selectedMidiClockHostId || 'none'}
+                onChange={(e) => setSelectedMidiClockHostId(e.target.value)}
+                className={styles.selectInput}
+              >
+                {availableMidiClockHosts.map(host => (
+                  <option key={host.id} value={host.id}>
+                    {host.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className={styles.configNote}>
+              <i className="fas fa-info-circle"></i>
+              <p>Select the source for MIDI clock synchronization. 'Ableton Sync Link' requires compatible Link-enabled software on the network.</p>
+            </div>
+          </div>
+        </div>
         
         {/* UI Theme Settings Card */}
         {/* ... */}

--- a/react-app/src/pages/MainPage.tsx
+++ b/react-app/src/pages/MainPage.tsx
@@ -6,6 +6,9 @@ import { useStore } from '../store'
 import { DmxControlPanel } from '../components/dmx/DmxControlPanel'
 import { MasterFader } from '../components/dmx/MasterFader'
 import { MidiOscSetup } from '../components/midi/MidiOscSetup'
+import { MidiMonitor } from '../components/midi/MidiMonitor'
+import { OscMonitor } from '../components/osc/OscMonitor'
+import { MidiClock } from '../components/midi/MidiClock' // Added MidiClock import
 import { OscDebug } from '../components/osc/OscDebug'
 import { TouchOSCExporter } from '../components/osc/TouchOSCExporter'
 import { AudioControlPanel } from '../components/audio/AudioControlPanel'
@@ -58,6 +61,9 @@ const MainPage: React.FC = () => {
             <>
               <MasterFader />
               <DmxControlPanel />
+              <MidiMonitor />
+              <OscMonitor />
+              <MidiClock /> {/* Added MidiClock */}
             </>
           )}
           {currentView === 'midiOsc' && <MidiOscSetup />}

--- a/react-app/src/store/index.ts
+++ b/react-app/src/store/index.ts
@@ -160,7 +160,12 @@ interface State {
   // Socket state
   socket: Socket | null
   setSocket: (socket: Socket | null) => void
-    // Actions
+
+  // MIDI Clock Sync State
+  availableMidiClockHosts: Array<{ id: string; name: string }>;
+  selectedMidiClockHostId: string | null;
+
+  // Actions
   fetchInitialState: () => Promise<void>
   setDmxChannel: (channel: number, value: number) => void 
   setDmxChannelValue: (channel: number, value: number) => void 
@@ -210,7 +215,9 @@ interface State {
   updateMasterSliderValue: (sliderId: string, value: number) => void;
   updateMasterSlider: (sliderId: string, updatedSlider: Partial<MasterSlider>) => void; 
   removeMasterSlider: (sliderId: string) => void;
-  setMasterSliders: (sliders: MasterSlider[]) => void; 
+  setMasterSliders: (sliders: MasterSlider[]) => void;
+  setSelectedMidiClockHostId: (hostId: string | null) => void;
+  setAvailableMidiClockHosts: (hosts: Array<{ id: string; name: string }>) => void;
 }
 
 export const useStore = create<State>()(
@@ -265,6 +272,14 @@ export const useStore = create<State>()(
       
       socket: null,
       setSocket: (socket) => set({ socket }),
+
+      // MIDI Clock Sync State Init
+      availableMidiClockHosts: [
+        { id: 'none', name: 'None (Internal Clock)' },
+        { id: 'ableton-link', name: 'Ableton Sync Link' },
+        // Other hosts would be populated dynamically
+      ],
+      selectedMidiClockHostId: 'none',
       
       // Actions
       fetchInitialState: async () => {
@@ -737,6 +752,17 @@ export const useStore = create<State>()(
       },
       setMasterSliders: (sliders) => {
         set({ masterSliders: sliders });
+      },
+      setSelectedMidiClockHostId: (hostId) => {
+        set({ selectedMidiClockHostId: hostId });
+        // Potentially add logic here to initiate connection/disconnection if needed globally
+        get().addNotification({
+          message: `MIDI Clock Sync source set to ${get().availableMidiClockHosts.find(h => h.id === hostId)?.name || 'None'}`,
+          type: 'info',
+        });
+      },
+      setAvailableMidiClockHosts: (hosts) => {
+        set({ availableMidiClockHosts: hosts });
       },
     }),
     { name: 'ArtBastard-DMX-Store' } 


### PR DESCRIPTION
This commit addresses several UI and UX issues:

1.  **MIDI and OSC Monitors:**
    - Added MIDI Monitor and OSC Monitor to the main application page.
    - Both monitors are now draggable, pinnable, and collapsible, allowing you to customize your workspace.
    - Implemented using react-draggable and lucide-react for controls.

2.  **MIDI Clock:**
    - Relocated the MIDI Clock to the main page (created as a new component as the original was not found).
    - Made the MIDI Clock draggable and collapsible.
    - Added functionality in MIDI settings to select a sync host (including "Ableton Sync Link" and "None (Internal Clock)").
    - The MidiClock component now displays the selected host and a placeholder sync status.
    - Internal transport controls on the clock are disabled when an external sync source is selected.
    - Note: Actual Ableton Sync Link synchronization logic is not implemented in this commit; the UI reflects selection, but core sync functionality is pending.

3.  **Collapsible Navbar:**
    - Modified the main Navbar to be fully collapsible (`display: none`).
    - The toggle button for expanding/collapsing the Navbar remains visible and functional, ensuring the Navbar does not take up main page space when collapsed.

4.  **DMX Channel Fullscreen:**
    - Ensured that when a DMX Channel is in fullscreen mode, it has an opaque background (`#18181b`), preventing underlying UI elements from being visible.

These changes aim to improve your experience by providing more flexible and clear UI components for monitoring and control.