### PR TITLE
feat: Implement Master Clock System and Improve Master Fader

### DIFF
--- a/react-app/src/components/midi/MidiOscSetup.tsx
+++ b/react-app/src/components/midi/MidiOscSetup.tsx
@@ -26,6 +26,21 @@ export const MidiOscSetup: React.FC = () => {
   
   const midiMessages = useStore(state => state.midiMessages)
   const clearAllMidiMappings = useStore(state => state.clearAllMidiMappings)
+
+  // Zustand store values for Master Clock
+  const {
+    availableMidiClockHosts,
+    selectedMidiClockHostId,
+    midiClockBpm,
+    setSelectedMidiClockHostId,
+    setMidiClockBpm,
+  } = useStore(state => ({
+    availableMidiClockHosts: state.availableMidiClockHosts,
+    selectedMidiClockHostId: state.selectedMidiClockHostId,
+    midiClockBpm: state.midiClockBpm,
+    setSelectedMidiClockHostId: state.setSelectedMidiClockHostId,
+    setMidiClockBpm: state.setMidiClockBpm,
+  }));
   
   // Request MIDI interfaces on component mount
   useEffect(() => {
@@ -358,6 +373,55 @@ export const MidiOscSetup: React.FC = () => {
               {theme === 'standard' && 'Click "MIDI Learn" on any DMX channel and move a control on your MIDI device to create a mapping.'}
               {theme === 'minimal' && 'Use MIDI Learn on DMX channels to map controls.'}
             </p>
+          </div>
+        </div>
+
+        {/* Master Clock Settings Card */}
+        <div className={styles.card}>
+          <div className={styles.cardHeader}>
+            <h3>
+              {theme === 'artsnob' && 'Chronometer Configuration: The Pulse of Creation'}
+              {theme === 'standard' && 'Master Clock Settings'}
+              {theme === 'minimal' && 'Master Clock'}
+            </h3>
+          </div>
+          <div className={styles.cardBody}>
+            <div className={styles.formGroup}>
+              <label htmlFor="masterClockSource">Master Clock Source:</label>
+              <select
+                id="masterClockSource"
+                value={selectedMidiClockHostId || ''}
+                onChange={(e) => setSelectedMidiClockHostId(e.target.value)}
+                className={styles.selectInput}
+              >
+                {availableMidiClockHosts.map(host => (
+                  <option key={host.id} value={host.id}>
+                    {host.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {selectedMidiClockHostId === 'internal' && (
+              <div className={styles.formGroup}>
+                <label htmlFor="internalBpm">Internal Clock BPM:</label>
+                <input
+                  type="number"
+                  id="internalBpm"
+                  value={midiClockBpm}
+                  onChange={(e) => {
+                    const newBpm = parseFloat(e.target.value);
+                    if (!isNaN(newBpm)) {
+                      setMidiClockBpm(newBpm);
+                    }
+                  }}
+                  min="30"
+                  max="300"
+                  step="0.01"
+                  className={styles.numberInput}
+                />
+              </div>
+            )}
           </div>
         </div>
         

--- a/src/clockManager.ts
+++ b/src/clockManager.ts
@@ -1,0 +1,175 @@
+// src/clockManager.ts
+
+export type MasterClockSourceId = 'internal' | 'ableton-link-placeholder'; // Extensible later
+
+export interface ClockState {
+  bpm: number;
+  isPlaying: boolean;
+  source: MasterClockSourceId;
+  beat: number; // Current beat in the bar (e.g., 1, 2, 3, 4 for 4/4)
+  bar: number;  // Current bar number
+}
+
+export class ClockManager {
+  private currentSource: MasterClockSourceId = 'internal';
+  private internalBPM: number = 120.0;
+  private isInternalPlaying: boolean = false;
+  private internalIntervalId: NodeJS.Timeout | null = null;
+  private beat: number = 1; // Current beat, 1-indexed
+  private bar: number = 1;  // Current bar, 1-indexed
+  private timeSignatureNominator: number = 4; // e.g., 4 for 4/4 time
+
+  private subscribers: Array<(state: ClockState) => void> = [];
+
+  constructor() {
+    // Initialization logic, if any, beyond property defaults
+  }
+
+  public subscribe(callback: (state: ClockState) => void): () => void {
+    this.subscribers.push(callback);
+    // Return an unsubscribe function
+    return () => {
+      this.subscribers = this.subscribers.filter(sub => sub !== callback);
+    };
+  }
+
+  private notifySubscribers(): void {
+    const state = this.getCurrentClockState();
+    this.subscribers.forEach(callback => callback(state));
+  }
+
+  private getCurrentClockState(): ClockState {
+    return {
+      bpm: this.currentSource === 'internal' ? this.internalBPM : 0, // Placeholder for non-internal BPM
+      isPlaying: this.currentSource === 'internal' ? this.isInternalPlaying : false, // Placeholder
+      source: this.currentSource,
+      beat: this.beat,
+      bar: this.bar,
+    };
+  }
+
+  public setSource(sourceId: MasterClockSourceId): void {
+    if (this.currentSource === sourceId) return;
+
+    this.currentSource = sourceId;
+
+    if (sourceId === 'internal') {
+      // If switching to internal, respect its current play state
+      if (this.isInternalPlaying && !this.internalIntervalId) {
+        this.startInternalClock(false); // Start without resetting beat/bar immediately
+      } else if (!this.isInternalPlaying && this.internalIntervalId) {
+        this.stopInternalClock();
+      }
+    } else if (sourceId === 'ableton-link-placeholder') {
+      this.stopInternalClock(); // Stop internal clock if switching away
+      // Future: Initialize Ableton Link connection etc.
+      console.log('Ableton Link selected (not implemented). Internal clock stopped.');
+    }
+    this.notifySubscribers();
+  }
+
+  public setBPM(newBPM: number): void {
+    if (newBPM <= 0) {
+      console.warn('BPM must be positive.');
+      return;
+    }
+    this.internalBPM = newBPM;
+
+    if (this.currentSource === 'internal' && this.isInternalPlaying) {
+      this.stopInternalClock();
+      this.startInternalClock(false); // Restart with new BPM, don't reset beat/bar
+    }
+    this.notifySubscribers();
+  }
+
+  public togglePlayPause(): void {
+    if (this.currentSource === 'internal') {
+      if (this.isInternalPlaying) {
+        this.stopInternalClock();
+      } else {
+        this.startInternalClock(true); // Reset beat/bar on play
+      }
+    } else if (this.currentSource === 'ableton-link-placeholder') {
+      console.log('Play/Pause for Ableton Link not implemented.');
+      // Future: Send play/pause to Ableton Link
+    }
+    // No direct notifySubscribers here, as start/stopInternalClock will do it.
+  }
+
+  public getAvailableSources(): Array<{ id: MasterClockSourceId; name: string }> {
+    return [
+      { id: 'internal', name: 'Internal Clock' },
+      { id: 'ableton-link-placeholder', name: 'Ableton Link (Not Implemented)' }
+    ];
+  }
+
+  public getState(): ClockState {
+    return this.getCurrentClockState();
+  }
+
+  private startInternalClock(resetBeatBar: boolean = true): void {
+    if (this.internalIntervalId) return; // Already running
+
+    this.isInternalPlaying = true;
+    if (resetBeatBar) {
+      this.beat = 1;
+      this.bar = 1;
+    }
+
+    const intervalMilliseconds = (60000 / this.internalBPM);
+    this.internalIntervalId = setInterval(() => this.handleInternalTick(), intervalMilliseconds);
+
+    console.log(`Internal clock started. BPM: ${this.internalBPM}. Beat/Bar reset: ${resetBeatBar}`);
+    this.notifySubscribers();
+  }
+
+  private stopInternalClock(): void {
+    if (this.internalIntervalId) {
+      clearInterval(this.internalIntervalId);
+      this.internalIntervalId = null;
+    }
+    this.isInternalPlaying = false;
+    console.log('Internal clock stopped.');
+    this.notifySubscribers();
+  }
+
+  private handleInternalTick(): void {
+    this.beat++;
+    if (this.beat > this.timeSignatureNominator) {
+      this.beat = 1;
+      this.bar++;
+      // Future: Add logic for bar limits or looping if needed
+    }
+    // console.log(`Tick: Bar ${this.bar}, Beat ${this.beat}`); // For debugging
+    this.notifySubscribers();
+  }
+
+  // --- Additional methods for controlling beat/bar might be needed later ---
+  public setBeat(beat: number): void {
+    if (beat > 0 && beat <= this.timeSignatureNominator) {
+        this.beat = beat;
+        this.notifySubscribers();
+    }
+  }
+
+  public setBar(bar: number): void {
+    if (bar > 0) {
+        this.bar = bar;
+        this.notifySubscribers();
+    }
+  }
+
+  public setTimeSignatureNominator(nominator: number): void {
+    if (nominator > 0) {
+        this.timeSignatureNominator = nominator;
+        // Optionally reset beat/bar or adjust if current beat > new nominator
+        if (this.beat > nominator) {
+            this.beat = 1;
+            this.bar++; // Or handle differently
+        }
+        this.notifySubscribers();
+    }
+  }
+}
+
+export const clockManager = new ClockManager();


### PR DESCRIPTION
This commit introduces a backend-driven Master Clock system and addresses issues with the Master Fader.

Key Changes:

**Master Fader:**
- Fixed reported unresponsiveness of the master fader slider. The slider knob should now visually update correctly when dragged.
- Refined and verified the state retention logic for the master fader:
    - When the fader goes to 0, current DMX channel values (normalized to their 100% master equivalent) are stored.
    - When the fader moves from 0 to a positive value, these stored normalized values are restored proportionally to the new fader level.
    - Live scaling logic for when the fader moves between non-zero values has also been reviewed and refactored for clarity.

**Master Clock System:**
- **Backend:**
    - Introduced a new `ClockManager` module (`src/clockManager.ts`) to handle master clock logic.
    - Implemented a functional Internal MIDI Clock within the `ClockManager`, capable of managing BPM, play/pause state, and beat/bar counting.
    - The `ClockManager` is integrated with the main server (`src/server.ts`), broadcasting clock updates (BPM, play state, source, beat, bar) to all clients via WebSockets (`masterClockUpdate` message).
    - Added WebSocket event handlers for clients to:
        - Select the master clock source (`setMasterClockSource`).
        - Control the internal clock's BPM (`setInternalClockBPM`). - Toggle play/pause state (`toggleMasterClockPlayPause`). - Receive the list of available clock sources (`availableClockSources`).
    - Includes a placeholder for future Ableton Link integration.
- **Frontend (Store & UI):**
    - Zustand store (`react-app/src/store/index.ts`) actions for clock control now send commands to the backend. The store's clock state is updated via WebSocket messages from the server.
    - WebSocket listeners added in `react-app/src/context/SocketContext.tsx` to handle `masterClockUpdate` and `availableClockSources` messages, updating the Zustand store.
    - In `react-app/src/components/midi/MidiOscSetup.tsx`:
        - Added a "Master Clock Settings" section.
        - You can now select the master clock source (e.g., "Internal Clock"). - You can set the BPM for the Internal Clock when it's the selected source.
    - In `react-app/src/components/midi/MidiClock.tsx` (Clock Display Widget): - Removed its local internal clock timing logic. - Now displays clock information (source, BPM, play state, beat, bar) driven by the backend via the Zustand store. - Play/Pause controls now interact with the backend's master clock.

This set of changes provides a more robust and centralized clocking mechanism and improves the functionality of the master fader.