### PR TITLE
feat: Enhance Fixture Group controls and functionality

### DIFF
--- a/react-app/src/components/fixtures/FixtureGroup.tsx
+++ b/react-app/src/components/fixtures/FixtureGroup.tsx
@@ -18,7 +18,10 @@ export const FixtureGroup: React.FC<FixtureGroupProps> = ({ group, onEdit }) => 
     setGroupSolo,
     startMidiLearn,
     cancelMidiLearn,
-    midiLearnTarget 
+    midiLearnTarget,
+    setGroupPanOffset,
+    setGroupTiltOffset,
+    setGroupZoomValue
   } = useStore(state => ({
     updateGroup: state.updateGroup,
     saveGroupLastStates: state.saveGroupLastStates,
@@ -27,7 +30,10 @@ export const FixtureGroup: React.FC<FixtureGroupProps> = ({ group, onEdit }) => 
     setGroupSolo: state.setGroupSolo,
     startMidiLearn: state.startMidiLearn,
     cancelMidiLearn: state.cancelMidiLearn,
-    midiLearnTarget: state.midiLearnTarget
+    midiLearnTarget: state.midiLearnTarget,
+    setGroupPanOffset: state.setGroupPanOffset,
+    setGroupTiltOffset: state.setGroupTiltOffset,
+    setGroupZoomValue: state.setGroupZoomValue,
   }));
 
   // Clean up any active fade on unmount
@@ -99,10 +105,8 @@ export const FixtureGroup: React.FC<FixtureGroupProps> = ({ group, onEdit }) => 
   };
 
   const handleSoloToggle = () => {
-    if (!group.isSolo) {
-      // Save states before soloing
-      saveGroupLastStates(group.id);
-    }
+    // saveGroupLastStates(group.id) was removed as per plan.
+    // Soloing is a filter, not a state to be saved/restored like mute.
     setGroupSolo(group.id, !group.isSolo);
   };
   const handleMidiLearnClick = () => {
@@ -207,7 +211,7 @@ export const FixtureGroup: React.FC<FixtureGroupProps> = ({ group, onEdit }) => 
             Mute
           </button>
           <button
-            className={`${styles.soloButton} ${group.isSolo ? styles.active : ''}`}
+            className={`${styles.soloButton} ${group.isSolo && !group.isMuted ? styles.active : ''}`}
             onClick={handleSoloToggle}
             title={group.isSolo ? "Un-solo" : "Solo"}
           >
@@ -230,6 +234,45 @@ export const FixtureGroup: React.FC<FixtureGroupProps> = ({ group, onEdit }) => 
             <i className="fas fa-sliders-h" />
             Ignore Master
           </button>
+        </div>
+
+        <div className={styles.ptzControls}>
+          <div className={styles.ptzSliderControl}>
+            <label htmlFor={`panOffset-${group.id}`}>Pan Offset: {group.panOffset || 0}</label>
+            <input
+              type="range"
+              id={`panOffset-${group.id}`}
+              min="-127"
+              max="127"
+              value={group.panOffset || 0}
+              onChange={(e) => setGroupPanOffset(group.id, parseInt(e.target.value))}
+              className={styles.slider}
+            />
+          </div>
+          <div className={styles.ptzSliderControl}>
+            <label htmlFor={`tiltOffset-${group.id}`}>Tilt Offset: {group.tiltOffset || 0}</label>
+            <input
+              type="range"
+              id={`tiltOffset-${group.id}`}
+              min="-127"
+              max="127"
+              value={group.tiltOffset || 0}
+              onChange={(e) => setGroupTiltOffset(group.id, parseInt(e.target.value))}
+              className={styles.slider}
+            />
+          </div>
+          <div className={styles.ptzSliderControl}>
+            <label htmlFor={`zoom-${group.id}`}>Zoom: {group.zoomValue || 0}</label>
+            <input
+              type="range"
+              id={`zoom-${group.id}`}
+              min="0"
+              max="255"
+              value={group.zoomValue || 0}
+              onChange={(e) => setGroupZoomValue(group.id, parseInt(e.target.value))}
+              className={styles.slider}
+            />
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This commit introduces several enhancements to Fixture Groups:

1.  **State for PAN/TILT/ZOOM:**
    *   The `Group` interface in the Zustand store (`react-app/src/store/index.ts`)
        now includes `panOffset`, `tiltOffset`, and `zoomValue` properties
        to enable these controls at the group level.

2.  **Core DMX Recalculation Logic:**
    *   A new centralized function `_recalculateDmxOutput` has been implemented
        in the Zustand store. This function is responsible for calculating
        the final DMX output based on group properties including P/T/Z offsets,
        master fader values, mute states, and solo states.
    *   It correctly considers fixture channel types (DIMMER, INTENSITY, PAN,
        TILT, ZOOM) for applying these controls.

3.  **Updated Group Control Actions:**
    *   Existing actions `setGroupMasterValue`, `setGroupMute`, and `setGroupSolo`
        in the Zustand store have been refactored to use the new
        `_recalculateDmxOutput` function.
    *   New actions `setGroupPanOffset`, `setGroupTiltOffset`, and
        `setGroupZoomValue` were added to manage the new P/T/Z properties,
        also leveraging `_recalculateDmxOutput`.
    *   The logic for `group.lastStates` has been integrated to ensure correct
        DMX value restoration when unmuting or fading a group up from zero.

4.  **UI for PAN/TILT/ZOOM:**
    *   The `FixtureGroup.tsx` component now includes sliders for controlling
        Pan Offset, Tilt Offset, and Zoom Value for each group. These controls
        are linked to the new Zustand store actions.
    *   Basic styling for these new UI elements has been added in
        `FixtureGroup.module.scss`.

5.  **Refined Solo UI:**
    *   The Solo button in `FixtureGroup.tsx` now visually reflects an active
        solo state only if the group is `isSolo && !isMuted`.
    *   The component's `handleSoloToggle` was cleaned up, removing a
        redundant `saveGroupLastStates` call.

These changes provide more granular control over fixture groups and centralize the DMX processing logic for group operations within the frontend state management, leading to more consistent behavior.