### PR TITLE
Fix: Correct syntax error in tsconfig.json

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2020",
     "module": "CommonJS",
     "outDir": "./dist",
-z    "rootDir": "./src",
+    "rootDir": "./src",
     "strict": false,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,


### PR DESCRIPTION
An extraneous 'z' character was present before the 'rootDir' property in tsconfig.json, causing TypeScript compilation to fail. This commit removes the typo.