### PR TITLE
Supercontrol user experience

### DIFF
--- a/react-app/src/components/dmx/SuperControl.module.scss
+++ b/react-app/src/components/dmx/SuperControl.module.scss
@@ -1435,6 +1435,70 @@
       }
     }
   }
+
+  .selectionToolbar {
+    display: flex;
+    gap: 8px;
+    align-items: center;
+    margin-bottom: 12px;
+    flex-wrap: wrap;
+  }
+
+  .selectionSearch {
+    flex: 1;
+    min-width: 220px;
+    padding: 8px 10px;
+    border-radius: 8px;
+    border: 1px solid rgba(255, 255, 255, 0.18);
+    background: rgba(0, 0, 0, 0.25);
+    color: #fff;
+    font-size: 0.85rem;
+
+    &:focus {
+      outline: none;
+      border-color: rgba(0, 212, 255, 0.6);
+      box-shadow: 0 0 0 2px rgba(0, 212, 255, 0.15);
+    }
+
+    &::placeholder {
+      color: rgba(255, 255, 255, 0.55);
+    }
+  }
+
+  .selectionActions {
+    display: flex;
+    gap: 6px;
+    flex-wrap: wrap;
+
+    button {
+      padding: 8px 10px;
+      border-radius: 8px;
+      border: 1px solid rgba(255, 255, 255, 0.14);
+      background: rgba(255, 255, 255, 0.08);
+      color: #e2e8f0;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      font-weight: 600;
+      font-size: 0.8rem;
+      min-width: 64px;
+
+      &:hover:not(:disabled) {
+        background: rgba(255, 255, 255, 0.14);
+        border-color: rgba(0, 212, 255, 0.35);
+        transform: translateY(-1px);
+      }
+
+      &:active:not(:disabled) {
+        transform: translateY(0);
+      }
+
+      &:disabled {
+        opacity: 0.45;
+        cursor: not-allowed;
+        transform: none;
+      }
+    }
+  }
   
   .fixtureList {
     max-height: 150px;
@@ -1471,6 +1535,13 @@
         opacity: 0.7;
       }
     }
+  }
+
+  .emptySelection {
+    padding: 10px 12px;
+    color: rgba(255, 255, 255, 0.65);
+    font-size: 0.85rem;
+    font-style: italic;
   }
 }
 

--- a/react-app/src/store/store.test.ts
+++ b/react-app/src/store/store.test.ts
@@ -23,16 +23,16 @@ describe('Store', () => {
     })
 
     it('should set a DMX channel value', () => {
-      useStore.getState().setDmxChannel(1, 255)
+      useStore.getState().setDmxChannel(0, 255)
       const state = useStore.getState()
       expect(state.dmxChannels[0]).toBe(255)
     })
 
     it('should clamp DMX values to 0-255', () => {
-      useStore.getState().setDmxChannel(1, 300)
+      useStore.getState().setDmxChannel(0, 300)
       expect(useStore.getState().dmxChannels[0]).toBe(255)
       
-      useStore.getState().setDmxChannel(1, -10)
+      useStore.getState().setDmxChannel(0, -10)
       expect(useStore.getState().dmxChannels[0]).toBe(0)
     })
   })

--- a/react-app/src/utils/inputValidation.ts
+++ b/react-app/src/utils/inputValidation.ts
@@ -12,10 +12,10 @@ export interface ValidationResult {
  * Validate DMX channel value (0-255)
  */
 export function validateDmxValue(value: any): ValidationResult {
-  const num = Number(value);
-  if (isNaN(num)) {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
     return { valid: false, error: 'Value must be a number' };
   }
+  const num = value;
   if (num < 0 || num > 255) {
     return { valid: false, error: 'DMX value must be between 0 and 255' };
   }

--- a/start.ps1
+++ b/start.ps1
@@ -1,4 +1,4 @@
-﻿param(
+param(
     [switch]$Clear,
     [switch]$Reset,
     [switch]$Help,
@@ -633,7 +633,7 @@ if ($Clear) {
     Write-Host ""
     try {
         $env:PORT = $Port
-        npm start
+        node dist/server.js
     } catch {
         Write-Host "❌ Server deployment encountered complications!" -ForegroundColor Red
         Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow
@@ -878,7 +878,7 @@ if (-not $Clear) {
     # Deploy the server with sophistication
     try {
         $env:PORT = $Port
-        npm start
+        node dist/server.js
     } catch {
         Write-Host "❌ Server deployment encountered complications!" -ForegroundColor Red
         Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow
@@ -1341,7 +1341,7 @@ Update-ETAMetrics $totalTime
 try {
     Write-Host "Initiating ArtBastard DMX512 server deployment on port $Port..." -ForegroundColor Green
     $env:PORT = $Port
-    npm start
+    node dist/server.js
 } catch {
     Write-Host "Server deployment encountered architectural complications!" -ForegroundColor Red
     Write-Host "Error: $($_.Exception.Message)" -ForegroundColor Yellow

--- a/start.sh
+++ b/start.sh
@@ -403,7 +403,7 @@ if [ "$CLEAR" = true ]; then
     echo "🎭  Starting ArtBastard DMX512 Server on port $PORT..."
     echo "🎭 ════════════════════════════════════════════════════════════════ 🎭"
     echo ""
-    PORT=$PORT npm start
+    PORT=$PORT node dist/server.js
     
     # Cleanup browser job
     kill $BROWSER_PID 2>/dev/null || true
@@ -602,7 +602,7 @@ echo "🌐 Browser will launch automatically when server is ready..."
 BROWSER_PID=$(start_browser_when_ready)
 
 # Deploy the server
-PORT=$PORT npm start
+PORT=$PORT node dist/server.js
 
 # Cleanup browser job
 kill $BROWSER_PID 2>/dev/null || true


### PR DESCRIPTION
Improves Fast Start Mode to truly skip rebuilds and enhances SuperControl UX/UI, alongside fixing related tests.

The "Fast Start Mode" previously always triggered a backend rebuild due to calling `npm start`, defeating its purpose. SuperControl's user experience was improved by adding selection panel features (filter, All/None/Invert), optimizing performance, and correcting slider behavior. Associated DMX validation and store tests were also fixed to ensure system correctness.

---
<p><a href="https://cursor.com/agents/bc-7a1700c6-2adf-4649-8d4c-06540c9e50ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7a1700c6-2adf-4649-8d4c-06540c9e50ed"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes SuperControl control/selection behavior (notably tilt UI inversion and selection filtering) and updates start scripts to run `node dist/server.js`, which could affect local startup flows if builds are missing or assumptions differ.
> 
> **Overview**
> Improves `SuperControl` selection UX by adding a filterable selection toolbar for fixtures/groups/capabilities plus **All/None/Invert** actions and empty-state messaging, with matching SCSS styling.
> 
> Refactors selection/target computation to be memoized (`fixtureCapabilities`, filtered lists, `affectedFixtures`) and removes verbose debug logging; also aligns tilt UI behavior by inverting the slider/MIDI-driven XY mapping to match the XY pad.
> 
> Tightens `validateDmxValue` to only accept finite numbers (no implicit string coercion), fixes DMX channel store tests to use 0-based indices, and updates `start.sh`/`start.ps1` to launch the built backend via `node dist/server.js` instead of `npm start` (avoiding unnecessary rebuilds).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5512dc97a9b8cae77cd0e7a17100586dc25280b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->